### PR TITLE
Add segue subclass that presents without animation

### DIFF
--- a/DATBlurSegue/DATBlurSegue.m
+++ b/DATBlurSegue/DATBlurSegue.m
@@ -33,8 +33,12 @@
     
     [sourceViewController presentViewController:destinationViewController animated:NO completion:nil];
     
+    [self animateView:destinationViewController.view];
+}
+
+- (void)animateView:(UIView *)view {
     // We need to do a custom animation because presentViewController does not support UIModalPresentationCurrentContext
-    CGRect endRect = destinationViewController.view.frame;
+    CGRect endRect = view.frame;
     CGRect startRect = endRect;
     
     switch ([[UIApplication sharedApplication] statusBarOrientation]) {
@@ -54,10 +58,10 @@
             break;
     }
     
-    destinationViewController.view.frame = startRect;
+    view.frame = startRect;
     
     [UIView animateWithDuration:0.3 delay:0.0 options:UIViewAnimationOptionCurveEaseOut animations:^{
-        destinationViewController.view.frame = endRect;
+        view.frame = endRect;
     } completion:nil];
 }
 

--- a/DATBlurSegue/DATBlurSegueWithoutAnimation.h
+++ b/DATBlurSegue/DATBlurSegueWithoutAnimation.h
@@ -1,0 +1,9 @@
+//
+//  DATBlurSegueWithoutAnimation.h
+//
+
+#import "DATBlurSegue.h"
+
+@interface DATBlurSegueWithoutAnimation : DATBlurSegue
+
+@end

--- a/DATBlurSegue/DATBlurSegueWithoutAnimation.m
+++ b/DATBlurSegue/DATBlurSegueWithoutAnimation.m
@@ -1,0 +1,13 @@
+//
+//  DATBlurSegueWithoutAnimation.m
+//
+
+#import "DATBlurSegueWithoutAnimation.h"
+
+@implementation DATBlurSegueWithoutAnimation
+
+- (void)animateView:(UIView *)view {
+    // Override to do nothing
+}
+
+@end


### PR DESCRIPTION
Sometimes I want to perform the segue (and present the modal view) without the animation. This is useful if, for example, you are presenting the modal when the app first launches.

I don't know of an easy way to pass parameters or configuration options to a segue, so I simply created a new segue type, DATBlurSegueWithoutAnimation, that inherits from DATBlurSegue but overrides the animation code to do nothing.

I don't know if this is the best way to do it; I'm open to alternatives.
